### PR TITLE
Fix 'warning: constant ::Fixnum, Bignum is deprecated'.

### DIFF
--- a/lib/cocoa/objc/method_def.rb
+++ b/lib/cocoa/objc/method_def.rb
@@ -177,7 +177,7 @@ module ObjC
         case value
         when TrueClass, FalseClass
           [:bool,value]
-        when Fixnum, Bignum
+        when Integer
           [TYPES[types[i]],value]
         when Float
           [:double,value]


### PR DESCRIPTION
This pull request fixes the following warnings.
> /usr/local/lib/ruby/gems/2.7.0/gems/cocoa-0.1.6/lib/cocoa/objc/method_def.rb:154: warning: constant ::Fixnum is deprecated
> /usr/local/lib/ruby/gems/2.7.0/gems/cocoa-0.1.6/lib/cocoa/objc/method_def.rb:154: warning: constant ::Fixnum is deprecated
> /usr/local/lib/ruby/gems/2.7.0/gems/cocoa-0.1.6/lib/cocoa/objc/method_def.rb:154: warning: constant ::Bignum is deprecated
